### PR TITLE
Convert single newlines into a space in HTML docs.

### DIFF
--- a/modernrpc/core.py
+++ b/modernrpc/core.py
@@ -165,7 +165,7 @@ class RPCMethod(object):
             import markdown
             return markdown.markdown(docstring)
 
-        return "<p>{}</p>".format(docstring.replace('\n\n', '</p><p>').replace('\n', '<br/'))
+        return "<p>{}</p>".format(docstring.replace('\n\n', '</p><p>').replace('\n', ' '))
 
     def check_permissions(self, request):
         """Call the predicate(s) associated with the RPC method, to check if the current request


### PR DESCRIPTION
### CHANGE SUMMARY

A single new in a docstring would be converted into a (broken) `<br/` string, causing the line to be ignored by some browsers until the next tag.  Because a single new line is often used to continue a paragraph without exceeding Python's 72 character docstring length convention, we now convert single newlines into spaces, which allows a paragraph to be formatted to the width of the browser window in plain RPC method documentation.

### SCREENSHOTS

Given the following docstring:

![image](https://user-images.githubusercontent.com/2406542/27651434-502048a6-5c06-11e7-9b3e-bdb27970801b.png)

In Chrome, the previous HTML rendered as follows:

![image](https://user-images.githubusercontent.com/2406542/27651483-80717a2a-5c06-11e7-8971-2284ddbdad0e.png)

After this change, it renders as:

![image](https://user-images.githubusercontent.com/2406542/27651508-930c9f5c-5c06-11e7-8401-ca8705fc0e09.png)



