### PR TITLE
Update entry_point.rst

### DIFF
--- a/docs/source/configuration_guide/entry_point.rst
+++ b/docs/source/configuration_guide/entry_point.rst
@@ -42,12 +42,12 @@ is useful, for example if you need to have different addresses to handle protoco
 
    from django.conf.urls import url
 
-   from modernrpc.handlers import JSONRPC, XMLRPC
+   from modernrpc.core import JSONRPC_PROTOCOL, XMLRPC_PROTOCOL
    from modernrpc.views import RPCEntryPoint
 
    urlpatterns = [
-       url(r'^json-rpc/$', RPCEntryPoint.as_view(protocol=JSONRPC)),
-       url(r'^xml-rpc/$', RPCEntryPoint.as_view(protocol=XMLRPC)),
+       url(r'^json-rpc/$', RPCEntryPoint.as_view(protocol=JSONRPC_PROTOCOL)),
+       url(r'^xml-rpc/$', RPCEntryPoint.as_view(protocol=XMLRPC_PROTOCOL)),
    ]
 
 .. _multiple_entry_points:


### PR DESCRIPTION
Using handlers instead protocol from core.py cause this error:

```
django.core.exceptions.ImproperlyConfigured: At least 1 handler must be instantiated.
```

Then i think that the documentation is old. Doing this way the error disappears and works well.
If i am wrong please excuse me and ignore this PR.

thanks for this library.