### PR TITLE
Fix passing of entrypoint to handler

### DIFF
--- a/modernrpc/views.py
+++ b/modernrpc/views.py
@@ -72,7 +72,7 @@ class RPCEntryPoint(TemplateView):
     @cached_property
     def handlers(self) -> Generator[RPCHandler, None, None]:
         for cls in self.handler_classes:
-            yield cls(self.protocol)
+            yield cls(self.entry_point)
 
     def post(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
Handler constructor expects to receive entrypoint name but it was given a protocol by mistake.

One of the end results was that when you don't specify protocol, Protocol.ALL is used which is the same string as "all entrypoints" making all methods available in all entrypoints regardless of what you specify in entrypoint configuration.