### PR TITLE
Improve security by using defusedxml when installed in environment

### DIFF
--- a/docs/advanced/security.rst
+++ b/docs/advanced/security.rst
@@ -1,0 +1,18 @@
+Security concerns
+=================
+
+Since django-modern-rpc uses builtin xmlrpc.client internally, it is vulnerable to various security issues related to
+XML payloads parsing. To protect you project against these attacks, you can install the package `defusedxml` in your
+environment.
+
+Alternatively, you can install django-modern-rpc with an extra to setup all at once :
+
+.. code-block:: bash
+
+    pip install django-modern-rpc[defusedxml]
+
+Once `defusedxml` can be imported, various method are automatically patched against multiple attacks vectors.
+
+For more information, check the `defusedxml project's`_ README.
+
+.. _defusedxml project: https://github.com/tiran/defusedxml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,8 +26,8 @@ While it is a bit outdated now, there is still use-cases were XML-RPC or JSON-RP
 Getting started
 ---------------
 
-.. important:: This library requires python 3.7 and Django 2.1. If you need to install it on older Python/Django
-   versions, you may need to install an older release.
+.. important:: django-modern-rpc requires python 3.7+ and Django 2.1+. If you need to install it in environment with
+   older Python/Django versions, you must install a previous release. See :ref:`Changelog` for more information.
 
 Installing the library and configuring a Django project to use it can be achieved in a few minutes. Follow
 :doc:`basics/quickstart` for very basic setup process. Later, when you will need to configure more precisely
@@ -56,6 +56,7 @@ your project, follow other topics in the menu.
    advanced/implementation_details.rst
    advanced/authentication.rst
    advanced/generated_doc.rst
+   advanced/security.rst
 
 .. toctree::
    :caption: Miscellaneous

--- a/modernrpc/apps.py
+++ b/modernrpc/apps.py
@@ -51,7 +51,7 @@ class ModernRpcConfig(AppConfig):
 
     def ready(self):
         self.rpc_methods_registration()
-        self.secure_xmlrpc_use()
+        self.defusedxml_monkey_patch()
 
     def rpc_methods_registration(self) -> None:
         """Store all decorated RPC methods as well as builtin system methods into internal registry"""
@@ -86,11 +86,16 @@ class ModernRpcConfig(AppConfig):
                     registry.register_method(func)
 
     @staticmethod
-    def secure_xmlrpc_use():
+    def defusedxml_monkey_patch():
         try:
             import defusedxml.xmlrpc
         except ImportError:
-            logger.debug("'defusedxml' package were not found, no protection will be enabled against XML based attacks")
+            msg = (
+                "'defusedxml' package were not found. Your project may be vulnerable to various XML payloads based "
+                "attacks. To secure the server against such malicious attacks, please install 'defusedxml' or install "
+                "django-modern-rpc with extra 'defusedxml (`pip install django-modern-rpc[defusedxml]`"
+            )
+            logger.debug(msg)
             return
-        else:
-            defusedxml.xmlrpc.monkey_patch()
+
+        defusedxml.xmlrpc.monkey_patch()

--- a/modernrpc/apps.py
+++ b/modernrpc/apps.py
@@ -51,6 +51,7 @@ class ModernRpcConfig(AppConfig):
 
     def ready(self):
         self.rpc_methods_registration()
+        self.secure_xmlrpc_use()
 
     def rpc_methods_registration(self) -> None:
         """Store all decorated RPC methods as well as builtin system methods into internal registry"""
@@ -83,3 +84,13 @@ class ModernRpcConfig(AppConfig):
                 # And register only functions with attribute 'modernrpc_enabled' defined to True
                 if getattr(func, "modernrpc_enabled", False):
                     registry.register_method(func)
+
+    @staticmethod
+    def secure_xmlrpc_use():
+        try:
+            import defusedxml.xmlrpc
+        except ImportError:
+            logger.debug("'defusedxml' package were not found, no protection will be enabled against XML based attacks")
+            return
+        else:
+            defusedxml.xmlrpc.monkey_patch()

--- a/modernrpc/handlers/xmlhandler.py
+++ b/modernrpc/handlers/xmlhandler.py
@@ -32,7 +32,7 @@ class XmlSuccessResult(SuccessResult):
         # a single <params> which contains a single <param> which contains a single <value>."
         #
         # So, to make sure the return value always contain a single '<param><value><type>X</type></value></param>',
-        # we dumps it as an array of a single value
+        # we dump it as an array of a single value
         return [self.data]
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -299,6 +299,17 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -1479,10 +1490,11 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
+defusedxml = ["defusedxml"]
 docutils = ["docutils"]
 markdown = ["markdown"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "e3bd53314bc3b84e98a073234fb345b8e8d1b4b0e4f9adad765a741e47948a9c"
+content-hash = "d7fe3b5d8c3f7d79b3769506f66427483496f551f3cf05d574e8a02a9050a224"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,13 @@ exclude = ["tests"]
 [tool.poetry.extras]
 docutils = ["docutils"]
 markdown = ["markdown"]
+defusedxml = ["defusedxml"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
 docutils = { version = "^0.19.0", optional = true }
 markdown = { version = "^3.4.0", optional = true }
+defusedxml = { version = "^0.7.1", optional = true }
 
 # Django group, allows tox to install a specific django version using pip
 # i.e. poetry install --without django
@@ -79,6 +81,7 @@ jsonrpcclient = "^4.0.2"
 requests = "*"
 docutils = "*"
 markdown = "*"
+defusedxml = "*"
 
 [tool.poetry.group.tests]
 optional = false
@@ -128,6 +131,12 @@ target-version = "py37"
 extend-exclude = [
     "module_with_syntax_errors.py",
 ]
+[[tool.mypy.overrides]]
+module = [
+    "defusedxml",
+    "defusedxml.xmlrpc",
+]
+ignore_missing_imports = true
 
 [tool.ruff.format]
 # Use `\n` line endings for all files

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,14 +1,15 @@
 import base64
-import itertools
-import pyexpat
 import xmlrpc.client
 from abc import ABC, abstractmethod
-from typing import Union, Type, Any, List, Dict, Optional
+from typing import Any, Dict, List, Optional, Type, Union
 
+import itertools
 import jsonrpcclient
+import pyexpat
 import pytest
 import requests
 from jsonrpcclient.sentinels import NOID
+
 
 UNDEFINED_AUTH = object()
 
@@ -71,7 +72,7 @@ class AbstractRpcTestClient(ABC):
 
     @abstractmethod
     def call(self, method: str, args: Optional[Union[List[Any], Dict[str, Any]]] = None):
-        """Perform a standard RPC call. Return the reote procedure execution result."""
+        """Perform a standard RPC call. Return the remote procedure execution result."""
 
     @abstractmethod
     def check_response_headers(self, headers):
@@ -286,3 +287,13 @@ def any_rpc_client(live_server, endpoint_path, client_auth, request):
     """A RPC client (xml-rpc or json-rpc)"""
     klass = request.param
     return klass(live_server.url + endpoint_path, auth=client_auth)
+
+
+@pytest.fixture()
+def _unconfigure_defusedxml():
+    """Ensure that builtin xmlrpc objects patched by defusedxml are unpatched before any tests are run"""
+    import defusedxml.xmlrpc
+
+    defusedxml.xmlrpc.unmonkey_patch()
+    yield
+    defusedxml.xmlrpc.monkey_patch()

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -1,0 +1,68 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+import requests
+
+from modernrpc.exceptions import RPC_INVALID_REQUEST
+
+
+class TestXmlBomb:
+    """Perform tests to ensure defusedxml is correctly used to parse incoming XML-RPC requests"""
+
+    # This is a malicious payload, with values defined from ENTITY definitions. This kind of variable setting can
+    # be used as a vecor attack to fill up server memory with hundreds of megabytes of data with a few lines of code.
+    # See https://github.com/tiran/defusedxml for more information
+    xml_bomb_payload = """
+    <!DOCTYPE xmlbomb [
+    <!ENTITY a "5">
+    <!ENTITY concat_a "&a;&a;&a;">
+    <!ENTITY b "6">
+    <!ENTITY concat_b "&b;&b;&b;">
+    ]>
+    <methodCall>
+      <methodName>add</methodName>
+      <params>
+         <param>
+            <value><int>&concat_a;</int></value>
+         </param>
+         <param>
+            <value><int>&concat_b;</int></value>
+         </param>
+      </params>
+    </methodCall>"""
+
+    def test_xml_bomb(self, live_server, endpoint_path):
+        """defusedxml is installed by default in 'dev' environment. As a result, XML-RPC request using ENTITY defined
+        variables become invalid"""
+        response = requests.post(
+            live_server.url + endpoint_path, data=self.xml_bomb_payload, headers={"content-type": "text/xml"}
+        )
+        tree = ET.fromstring(response.content)
+
+        fault_code = tree.find("./fault/value/struct/member/name[.='faultCode']/../value/int")
+        assert fault_code is not None
+        assert fault_code.text == str(RPC_INVALID_REQUEST)
+
+        fault_string = tree.find("./fault/value/struct/member/name[.='faultString']/../value/string")
+        assert fault_string is not None
+        assert "Invalid request" in fault_string.text
+
+        # No result in response payload
+        assert tree.find("./params/param/value/int") is None
+
+    @pytest.mark.usefixtures("_unconfigure_defusedxml")
+    def test_xml_bomb_without_defusedxml(self, live_server, endpoint_path):
+        """This test uses _unconfigure_defusedxml fixture to ensure defusedxml is disabled"""
+        response = requests.post(
+            live_server.url + endpoint_path,
+            data=self.xml_bomb_payload,
+            headers={"content-type": "text/xml"},
+        )
+        tree = ET.fromstring(response.content)
+
+        assert tree.find("./fault/value/struct/member/name[.='faultCode']/../value/int") is None
+        assert tree.find("./fault/value/struct/member/name[.='faultString']/../value/string") is None
+
+        result = tree.find("./params/param/value/int")
+        assert result is not None
+        assert result.text == "1221"


### PR DESCRIPTION
This change was originally suggested by @atodorov, thanks to him for this contribution.

Currently, django-modern-rpc uses builtin `xmlrpc.client.loads()` function to parse incoming requests. But this can cause a security issue when an attacker send a valid but malicious XML-RPC request.

A Python package can help to mitigate this kind of attack, [defusedxml](https://pypi.org/project/defusedxml/) ([GitHub repo](https://github.com/tiran/defusedxml)).

The goal of this PR is to implement `defusedxml` support in django-modern-rpc

Currently:
- defusedxml is added to extra dependencies
- `defusedxml.xmlrpc.monkey_patch()` is called from `ModernRpcConfig.ready()` when available
- 2 functional tests have been added to ensure
  - use of XML `<!ENTITY key "value">` syntax in XML-RPC request is disabled and raise an exception on parsing step
  - the same payload can work when `defusedxml.xmlrpc.monkey_patch()` is not called, or when `defusedxml.xmlrpc.unmonkey_patch()` is called after project initialization

Remaining
- [x] Mention the change in the documentation
- [x] Improve comments and docstring, specifically around tests

Drawbacks
- ~~Due to a limitation in the way `live_server` fixture has been customized for these tests, Django 2.1 cannot be supported anymore~~ edit: this is not true anymore