### PR TITLE
Add setting MODERNRPC_JSONRPC_VERSION_REQUIRED to disable jsonrpc check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements
 
+  - Setting `MODERNRPC_JSONRPC_VERSION_REQUIRED` to `False` disables the check
+  that `jsonrpc` is required to be supplied and set to `2.0` (#73). Thanks to @hwalinga
+
 ### Fixes
 
   - JSON-RPC handler now correctly checks type of request "id" field, according to the

--- a/docs/basics/settings.rst
+++ b/docs/basics/settings.rst
@@ -78,6 +78,14 @@ which improves the builtin python encoder by adding support for additional types
 
 .. _Django JSON encoder: https://docs.djangoproject.com/en/dev/topics/serialization/#djangojsonencoder
 
+MODERNRPC_JSONRPC_VERSION_REQUIRED
+----------------------------------
+
+:Required:  No
+:Default:   ``True``
+
+Set to ``False`` to disable check that jsonrpc attribute is supplied and set to `2.0`.
+
 MODERNRPC_XMLRPC_USE_BUILTIN_TYPES
 ----------------------------------
 

--- a/modernrpc/conf/default_settings.py
+++ b/modernrpc/conf/default_settings.py
@@ -14,6 +14,8 @@ MODERNRPC_XMLRPC_USE_BUILTIN_TYPES = True
 MODERNRPC_XMLRPC_ALLOW_NONE = True
 # Configure the default encoding used by XML encoder
 MODERNRPC_XMLRPC_DEFAULT_ENCODING = None
+# Configure if the jsonrpc is required by the client to specify (we only support "2.0" anyway)
+MODERNRPC_JSONRPC_VERSION_REQUIRED = True
 
 # List of handler classes used by default in any ``RPCEntryPoint`` instance
 MODERNRPC_HANDLERS = [

--- a/modernrpc/handlers/jsonhandler.py
+++ b/modernrpc/handlers/jsonhandler.py
@@ -9,7 +9,9 @@ from django.utils.module_loading import import_string
 
 from modernrpc.conf import settings
 from modernrpc.core import Protocol, RPCRequestContext
-from modernrpc.exceptions import RPC_INTERNAL_ERROR, RPC_INVALID_REQUEST, RPCException, RPCInvalidRequest, RPCParseError
+from modernrpc.exceptions import (RPC_INTERNAL_ERROR, RPC_INVALID_REQUEST,
+                                  RPCException, RPCInvalidRequest,
+                                  RPCParseError)
 from modernrpc.handlers.base import ErrorResult, RPCHandler, SuccessResult
 
 logger = logging.getLogger(__name__)
@@ -162,13 +164,14 @@ class JSONRPCHandler(RPCHandler):
             if not method_name:
                 raise RPCInvalidRequest('Missing parameter "method"')
 
-            if not jsonrpc_version:
-                raise RPCInvalidRequest('Missing parameter "jsonrpc"')
+            if settings.MODERNRPC_JSONRPC_VERSION_REQUIRED:
+                if not jsonrpc_version:
+                    raise RPCInvalidRequest('Missing parameter "jsonrpc"')
 
-            if jsonrpc_version != "2.0":
-                raise RPCInvalidRequest(
-                    f'Parameter "jsonrpc" has an unsupported value "{jsonrpc_version}". It must be set to "2.0"'
-                )
+                if jsonrpc_version != "2.0":
+                    raise RPCInvalidRequest(
+                        f'Parameter "jsonrpc" has an unsupported value "{jsonrpc_version}". It must be set to "2.0"'
+                    )
 
             if not is_notification and type(request_id) not in (type(None), int, float, str):
                 request_id = None
@@ -192,7 +195,7 @@ class JSONRPCHandler(RPCHandler):
 
         result.set_jsonrpc_data(
             request_id=request_id,
-            version=jsonrpc_version,
+            version="2.0",
             is_notification=is_notification,
         )
         return result

--- a/tests/functional/test_errors.py
+++ b/tests/functional/test_errors.py
@@ -110,6 +110,20 @@ class TestJsonRpcSpecificBehaviors:
         assert 'Missing parameter "jsonrpc"' in response["error"]["message"]
         assert response["error"]["code"] == RPC_INVALID_REQUEST
 
+    def test_version_not_required(self, live_server, endpoint_path, jsonrpc_content_type, settings):
+        # Missing 'jsonrpc' in payload but check disabled
+        settings.MODERNRPC_JSONRPC_VERSION_REQUIRED = False
+        headers = {"content-type": jsonrpc_content_type}
+        payload = {
+            "method": "add",
+            "params": [5, 6],
+            # "jsonrpc": "2.0",
+            "id": random.randint(1, 1000),
+        }
+        response = self.low_level_jsonrpc_call(live_server.url + endpoint_path, payload, headers=headers)
+
+        assert "error" not in response
+
     def test_invalid_version(self, live_server, endpoint_path, jsonrpc_content_type):
         # Bad value for payload member 'jsonrpc'
 


### PR DESCRIPTION
Hello alorence, 

Thank you for your project. 

This PR makes the jsonrpc=2.0 for the client, configurable to be optional. 

Since this project only supports 2.0, setting this version is only to be compliant to the spec, but redundant. For people that want this, disabling this, makes their client code simpler. The default is still compliant to the spec. 

 - [x] code
 - [x] test
 - [x] docs
 - [x] changelog

Thank you in advance, 

Kind regards, 

hwalinga